### PR TITLE
Use deep copy when merging dicts

### DIFF
--- a/db/tf2idb.py
+++ b/db/tf2idb.py
@@ -11,6 +11,7 @@ import sqlite3
 import traceback
 import time
 import collections
+import copy
 
 #https://gist.github.com/angstwad/bf22d1822c38a92ec0a9
 def dict_merge(dct, merge_dct):
@@ -29,22 +30,24 @@ def dict_merge(dct, merge_dct):
             dict_merge(dct[k], v)
         else:
             if (callable(getattr(v, "copy", None))):
-                dct[k] = v.copy()
+                dct[k] = copy.deepcopy(v)
             else:
                 dct[k] = v
 
-def resolve_prefabs(item, data):
-    prefabs = item.get('prefab')
-    prefab_aggregate = {}
-    if prefabs:
-        for prefab in prefabs.split():
-            prefab_data = data['prefabs'][prefab].copy()
-            prefab_data = resolve_prefabs(prefab_data, data)
-            dict_merge(prefab_aggregate, prefab_data)
-        dict_merge(prefab_aggregate, item)
-    else:
-        prefab_aggregate = item.copy()
-    return prefab_aggregate
+def resolve_prefabs(item, prefabs):
+    # generate list of prefabs
+    prefab_list = item.get('prefab', '').split()
+    for prefab in prefab_list:
+        subprefabs = prefabs[prefab].get('prefab', '').split()
+        prefab_list.extend(p for p in subprefabs if p not in prefab_list)
+    
+    # iterate over prefab list and merge, nested prefabs first
+    result = {}
+    for prefab in ( prefabs[p] for p in reversed(prefab_list) ):
+        dict_merge(result, prefab)
+    
+    dict_merge(result, item)
+    return result, prefab_list
 
 def main():
     data = None
@@ -159,7 +162,7 @@ def main():
     for id,v in data['items'].items():
         if id == 'default':
             continue
-        i = resolve_prefabs(v, data)
+        i, prefabs_used = resolve_prefabs(v, data['prefabs'])
         baseitem = 'baseitem' in i
 
         try:

--- a/db/tf2idb.py
+++ b/db/tf2idb.py
@@ -29,10 +29,7 @@ def dict_merge(dct, merge_dct):
         if (k in dct and isinstance(dct[k], dict) and isinstance(v, collections.Mapping)):
             dict_merge(dct[k], v)
         else:
-            if (callable(getattr(v, "copy", None))):
-                dct[k] = copy.deepcopy(v)
-            else:
-                dct[k] = v
+            dct[k] = copy.deepcopy(v)
 
 def resolve_prefabs(item, prefabs):
     # generate list of prefabs


### PR DESCRIPTION
`dict.copy()` copies nested `dict`s as references, which causes prefabs to be updated when merging.

PR makes merges using deep copies, so none of the prefab entries are accidentally updated.

Additional change to `resolve_prefabs` to append known prefabs to a list before merging.  Seems to resolve prefabs in a "correct" order (`kill_eater_score_type` from the `halloween2014` prefab was being shadowed by the same attribute in `cosmetic_killeater_attribs` before the function change).